### PR TITLE
Removed the MB unit from the name to prevent double MB indication on y-axis of graphs

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -97,10 +97,10 @@ UNIT_WIFI_NRML_NAME: str = WLAN1_NAME
 # counter
 UNIT_SENT_IDX: int = 5
 UNIT_SENT_IMG: str = ICON_FritzBox
-UNIT_SENT_NAME: str = "Sent MB"
+UNIT_SENT_NAME: str = "Sent"
 
 UNIT_RECEIVED_IDX: int = 6
-UNIT_RECEIVED_NAME: str = "Received MB"
+UNIT_RECEIVED_NAME: str = "Received"
 UNIT_RECEIVED_IMG: str = ICON_FritzBox
 
 # UNIT_RECEIVED_IDX_DBG: int = 7


### PR DESCRIPTION
The 'MB' unit is already configured as the ValueUnit when the counter is created. Leaving the MB as a suffix on the name, causes that the 'MB' unit is shown twice on the y-axis of the graph.
Removing the 'MB' from the initial default name of the counters, will result in an improved initial usage.